### PR TITLE
Webkit requires a specified margin for the thumb sliders.

### DIFF
--- a/css/brush-controls.css
+++ b/css/brush-controls.css
@@ -29,7 +29,9 @@
 #simplefog-brush-controls input[type=range]::-webkit-slider-thumb {
   -webkit-appearance: none;
   height: 24px;
+  margin-top: -10px;
 }
+
 
 /* Firefox */
 #simplefog-brush-controls input[type=range]::-moz-range-thumb {


### PR DESCRIPTION
I didn't notice that webkit browsers required this adjustment until opening the updated module in the electron app. This makes it consistent on firefox and webkit. I don't have access to IE to check that one.