### PR TITLE
Add option for confirmation on disabling of SimpleFog in a scene.

### DIFF
--- a/classes/SimplefogConfig.js
+++ b/classes/SimplefogConfig.js
@@ -38,6 +38,7 @@ export default class SimplefogConfig extends FormApplication {
       autoVisGM: canvas.simplefog.getSetting('autoVisGM'),
       vThreshold: Math.round(canvas.simplefog.getSetting('vThreshold') * 100),
       fogTextureFilePath: canvas.simplefog.getSetting('fogTextureFilePath'),
+      confirmDisablingFog: canvas.simplefog.getSetting( 'confirmDisablingFog'),
     };
   }
 

--- a/js/controls.js
+++ b/js/controls.js
@@ -17,8 +17,28 @@ Hooks.on('getSceneControlButtons', (controls) => {
         title: game.i18n.localize('SIMPLEFOG.onoff'),
         icon: 'fas fa-eye',
         onClick: () => {
-          canvas.simplefog.toggle();
-          canvas.sight.refresh();
+          if (canvas.simplefog.getSetting("confirmDisablingFog") && canvas.simplefog.getSetting("visible")) {
+            const dg = new Dialog({
+              title: game.i18n.localize('SIMPLEFOG.disableFog'),
+              content: game.i18n.localize('SIMPLEFOG.confirmDisableFog'),
+              buttons: {
+                reset: {
+                  icon: '<i class="fas fa-trash"></i>',
+                  label: 'Disable',
+                  callback: () => toggleSimpleFog(),
+                },
+                cancel: {
+                  icon: '<i class="fas fa-times"></i>',
+                  label: 'Cancel',
+                },
+              },
+              default: 'cancel',
+            });
+            dg.render(true);
+          //Original
+          } else {
+            toggleSimpleFog();
+          }
         },
         active: canvas.simplefog?.visible,
         toggle: true,
@@ -131,6 +151,14 @@ function setBrushControlPos() {
     const h = $('#navigation').height();
     bc.css({ top: `${h + 30}px` });
   }
+}
+
+/**
+ * Toggle Simple Fog
+ */
+function toggleSimpleFog() {
+  canvas.simplefog.toggle();
+  canvas.sight.refresh();
 }
 
 // Reset position when brush controls are rendered or sceneNavigation changes

--- a/lang/en.json
+++ b/lang/en.json
@@ -33,6 +33,10 @@
   "SIMPLEFOG.confirmReset": "Are you sure? Fog of war will be reset.",
   "SIMPLEFOG.autoFogSettings": "AutoFog Settings",
   "SIMPLEFOG.autoFogNotes": "When enabled AND saved as default, fog will automatically render when you create a scene. Please check box and click 'Save current setings as defualt' in order to enable. Do the same to disable",
+  "SIMPLEFOG.confirmDisablingFogSettings": "Confirm Disabling of Simple Fog",
+  "SIMPLEFOG.confirmDisablingFogNotes": "When disabling Simple Fog for a scene, present a dialog to confirm disabling before doing so.",
+  "SIMPLEFOG.disableFog": "Disable Simple Fog",
+  "SIMPLEFOG.confirmDisableFog": "Are you sure?  Fog of war will be disabled.",
 
   "SIMPLEFOG.autoVisNotes": "When enabled, Automatic Visibility will show/hide tokens based on fog opacity level at their location based on the threshold setting. Brush color changes to green/red to indicate whether a token would be visible.",
   "SIMPLEFOG.fogImageSettings": "Image Settings",

--- a/lang/es.json
+++ b/lang/es.json
@@ -36,6 +36,10 @@
   "SIMPLEFOG.confirmReset": "¿Está seguro? Se reiniciará la niebla de guerra",
   "SIMPLEFOG.autoFogSettings": "Ajustes de niebla automática",
   "SIMPLEFOG.autoFogNotes": "Cuando se activa y se guarda por defecto, la niebla se generará automáticamente cuando cree la escena. Por favor, active esta opción y pulse 'Guardar como por defecto los ajustes actuales' para habilitarlo. Realice el mismo proceso, pero al contrario, para deshabilitarlo",
+  "SIMPLEFOG.confirmDisablingFogSettings": "Confirmar la desactivación de la niebla simple",
+  "SIMPLEFOG.confirmDisablingFogNotes": "Al deshabilitar niebla para una escena, presente un cuadro de diálogo para confirmar la desactivación antes de hacerlo.",
+  "SIMPLEFOG.disableFog": "Desactivar niebla",
+  "SIMPLEFOG.confirmDisableFog": "¿Está seguro? La niebla de guerra se desactivará.",
 
   "SIMPLEFOG.autoVisNotes": "Cuando se activa, la visibilidad automática mostrará/ocultará los iconos en base al nivel de opacidad de la niebla en su localización y el umbral que se especifique. El color del pincel cambia a verde/rojo para indicar si el token es visible",
   "SIMPLEFOG.fogImageSettings": "Ajuste de la imagen",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -33,5 +33,9 @@
   "SIMPLEFOG.autoVisNotes": "自動可視化を有効にすると、その場所のトークンの表示/非表示が、閾値として設定した霧の濃度に基づいて決定されるようになります。非表示となる濃度では、ブラシの色が緑から赤に変化してそれを知らせます。",
   "SIMPLEFOG.fogImageSettings": "画像設定",
   "SIMPLEFOG.fogImage": "霧を上書きする画像",
-  "SIMPLEFOG.imageNotes": "指定した画像は霧の配色の上に表示されます。この画像はシーンの背景画像と同じ高さと幅を持つ必要があります。"
+  "SIMPLEFOG.imageNotes": "指定した画像は霧の配色の上に表示されます。この画像はシーンの背景画像と同じ高さと幅を持つ必要があります。",
+  "SIMPLEFOG.confirmDisablingFogSettings": "シンプルフォグの無効化を確認する",
+  "SIMPLEFOG.confirmDisablingFogNotes": "シーンのシンプルフォグを無効にする場合は、無効にする前に無効を確認するダイアログを表示します。",
+  "SIMPLEFOG.disableFog": "シンプルフォグを無効にする",
+  "SIMPLEFOG.confirmDisableFog": "本気ですか？ 戦場の霧は無効になります。"
 }

--- a/templates/scene-config.html
+++ b/templates/scene-config.html
@@ -88,6 +88,16 @@
         <label for="autoFog">{{localize 'SIMPLEFOG.enableAutoFog'}}</label>
         <input type='checkbox' {{#if autoFog}}checked{{/if}} name='autoFog' />
     </div>
+
+    <h3 class="form-header"><i class="fas fa-low-vision"></i> {{localize 'SIMPLEFOG.confirmDisablingFogSettings'}}</h3>
+      <p class="notes">
+        {{ localize 'SIMPLEFOG.confirmDisablingFogNotes' }}
+    </p>
+            <div class="form-group">
+        <label for="autoFog">{{localize 'SIMPLEFOG.confirmDisablingFog'}}</label>
+        <input type='checkbox' {{#if confirmDisablingFog}}checked{{/if}} name='confirmDisablingFog' />
+    </div>
+
     <hr>
     <footer class="sheet-footer flexrow">
         <button type="submit" name="saveDefaults">


### PR DESCRIPTION
With this option enabled, if the GM toggles the on/off for SimpleFog to disable in a scene, a confirmation dialog will be displayed.

Profuse apologies to native Spanish/Japanese speakers, as the translations are just Google translate until someone else offers alternatives...

League-of-Foundry-Developers/simplefog#50