### PR TITLE
feat: #107 - fixed renderer for foundry v11

### DIFF
--- a/src/classes/MaskLayer.js
+++ b/src/classes/MaskLayer.js
@@ -489,7 +489,13 @@ export default class MaskLayer extends InteractionLayer {
 	 * @param data {Object}       PIXI Object to be used as brush
 	 */
 	composite(brush) {
-		canvas.app.renderer.render(brush, this.maskTexture, false, null, false);
+		const opt = {
+			renderTexture: this.maskTexture,
+			clear: false,
+			transform: null,
+			skipUpdateTransform: false
+		}
+		canvas.app.renderer.render(brush, opt);
 	}
 
 	/**

--- a/src/classes/MaskLayer.js
+++ b/src/classes/MaskLayer.js
@@ -489,13 +489,18 @@ export default class MaskLayer extends InteractionLayer {
 	 * @param data {Object}       PIXI Object to be used as brush
 	 */
 	composite(brush) {
-		const opt = {
-			renderTexture: this.maskTexture,
-			clear: false,
-			transform: null,
-			skipUpdateTransform: false
+		if (isNewerVersion(game.version, "10.299")) {
+			const opt = {
+				renderTexture: this.maskTexture,
+				clear: false,
+				transform: null,
+				skipUpdateTransform: false
+			}
+			canvas.app.renderer.render(brush, opt);
 		}
-		canvas.app.renderer.render(brush, opt);
+		else {
+			canvas.app.renderer.render(brush, this.maskTexture, false, null, false);
+		}
 	}
 
 	/**

--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
 	"id": "simplefog",
 	"title": "Simplefog - Manual Fog of War",
 	"description": "Simplefog allows you to draw fog of war manually, optionally automatically hiding and revealing tokens underneath based on opacity. It provides a number of tools to quickly draw and erase fog in various shapes - brush, rectangles, ellipses, polygons or to reveal tiles you click/drag on the grid.",
-	"version": "0.3.1",
+	"version": "0.3.4",
 	"authors": [
 		{
 			"name": "Vance Cole",

--- a/src/module.json
+++ b/src/module.json
@@ -112,8 +112,8 @@
 	"styles": ["css/brush-controls.css"],
 	"compatibility": {
 		"minimum": 10,
-		"verified": 10.291,
-		"maximum": 10
+		"verified": 11.301,
+		"maximum": 11
 	},
 	"manifestPlusVersion": "1.2.1",
 	"url": "https://github.com/League-of-Foundry-Developers/simplefog",


### PR DESCRIPTION
This makes sure that simplefog can be used with Foundry v11. Foundry now uses Pixi.js v7 and due to that change the MaskLayer.ts needs an update on how to call the Renderer's render function.

Release Note 11.293 for Pixi.js v7: https://foundryvtt.com/releases/11.293 Can be found under **Web Workers Upgrading Our PIXIes**

API Documentation of latest PIXI.CanvasRenderer of latest release can be found under:
https://pixijs.download/release/docs/PIXI.CanvasRenderer.html#render

For this purpose I moved the options to their own object and passed in the newly created options object to the render function. Now simplefog works again.

Proof:
![2023-06-12 15_02_02-Foundry Virtual Tabletop](https://github.com/League-of-Foundry-Developers/simplefog/assets/8678523/5ba8b94a-6ae3-4c1d-8b5f-2143143f2078)

This affects issue #107 

Tested with Version 11.301

